### PR TITLE
Convert to PSR-0

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,4 @@
 <IfModule mod_rewrite.c>
 	RewriteEngine On
-	RewriteRule ^(spiffing\=.*)$ spiffing.php?file=$1 [L]
+	RewriteRule ^(spiffing\=.*)$ VisualIdiot/Spiffing/spiffing.php?file=$1 [L]
 </IfModule>

--- a/VisualIdiot/Spiffing/spiffing.php
+++ b/VisualIdiot/Spiffing/spiffing.php
@@ -32,6 +32,8 @@
  * @license 	☺ License (http://licence.visualidiot.com)
  *
  */
+	namespace VisualIdiot\Spiffing;
+
 	class spiffing {
 		/**
 		 * The dictionary which has been made into a more accessible array.

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 Why, hello, dear visitor! If you're the kind of person predisposed to converse about the weather over a round of tea and crumpets, then you'll appreciate Spiffing: a CSS preprocessor with only one job — to correct the spelling errors prevalent in the language.
 
 ## Requirements:
-PHP 5.2+, well-spelt CSS and Apache (if you want clean URLs).
+PHP 5.3+, well-spelt CSS and Apache (if you want clean URLs).
 
 ## To install:
 1. Download Spiffing (it's the ZIP button up there), and upload to your server.


### PR DESCRIPTION
Fine day, chaps!

Non-namespaced code is so continental. Spiffing should adopt [PSR-0](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md) to allow for polite commingling amongst civilised projects.

This would, however, increase Spiffing's requirements to PHP 5.3 or greater. Terribly sorry about that.
